### PR TITLE
fix the display of trick name when a trick is added, updated or deleted

### DIFF
--- a/src/Controller/TrickController.php
+++ b/src/Controller/TrickController.php
@@ -147,7 +147,7 @@ class TrickController extends AbstractController
             $trickService->delete($trick);
 
             return $this->json(
-                ['message' => 'Le trick '.$trickName.' a bien été supprimé.'],
+                ['message' => 'Le trick "'.strtoupper($trickName).'" a bien été supprimé.'],
                 200,
                 ['Content-Type' => 'application/json']
             );
@@ -181,7 +181,7 @@ class TrickController extends AbstractController
             $trickService->delete($trick);
             $this->addFlash(
                 'notice',
-                'Le trick "'.$trickName.'" a bien été supprimé.'
+                'Le trick "'.strtoupper($trickName).'" a bien été supprimé.'
             );
 
             return $this->redirectToRoute('tricks');

--- a/src/FormHandler/TrickFormHandler.php
+++ b/src/FormHandler/TrickFormHandler.php
@@ -47,7 +47,10 @@ class TrickFormHandler extends AbstractFormHandler
         $entityManager = $this->getManagerRegistry()->getManager();
         $entityManager->persist($trick);
         $entityManager->flush();
-        $this->session->getFlashBag()->add('notice', 'Le trick "'.strtoupper($trick->getName()).'" vient d\'être ajouté');
+        $this->session->getFlashBag()->add(
+            'notice',
+            'Le trick "'.strtoupper($trick->getName()).'" vient d\'être ajouté'
+        );
     }
 
     public function processPictures(Trick $trick): void

--- a/src/FormHandler/TrickFormHandler.php
+++ b/src/FormHandler/TrickFormHandler.php
@@ -47,7 +47,7 @@ class TrickFormHandler extends AbstractFormHandler
         $entityManager = $this->getManagerRegistry()->getManager();
         $entityManager->persist($trick);
         $entityManager->flush();
-        $this->session->getFlashBag()->add('notice', 'Le trick '.$trick->getName()." vient d'être ajouté");
+        $this->session->getFlashBag()->add('notice', 'Le trick "'.strtoupper($trick->getName()).'" vient d\'être ajouté');
     }
 
     public function processPictures(Trick $trick): void

--- a/src/Service/TrickUpdateFormService.php
+++ b/src/Service/TrickUpdateFormService.php
@@ -50,7 +50,10 @@ class TrickUpdateFormService implements TrickUpdateFormServiceInterface
         $this->processAddedVideos($trick);
         // save changes
         $this->managerRegistry->getManager()->flush();
-        $this->session->getFlashBag()->add('notice', 'Le trick "'.strtoupper($trick->getName()).'" vient d\'être modifié');
+        $this->session->getFlashBag()->add(
+            'notice',
+            'Le trick "'.strtoupper($trick->getName()).'" vient d\'être modifié'
+        );
     }
 
     public function processAddedPictures(FormInterface $form, Trick $trick): void

--- a/src/Service/TrickUpdateFormService.php
+++ b/src/Service/TrickUpdateFormService.php
@@ -50,7 +50,7 @@ class TrickUpdateFormService implements TrickUpdateFormServiceInterface
         $this->processAddedVideos($trick);
         // save changes
         $this->managerRegistry->getManager()->flush();
-        $this->session->getFlashBag()->add('notice', 'Le trick <'.$trick->getName()."> vient d'être modifié");
+        $this->session->getFlashBag()->add('notice', 'Le trick "'.strtoupper($trick->getName()).'" vient d\'être modifié');
     }
 
     public function processAddedPictures(FormInterface $form, Trick $trick): void


### PR DESCRIPTION
edit src/Controller/TrickController.php, src/FormHandler/TrickFormHandler.php and src/Service/TrickUpdateFormService.php to fix the display of trick name when a trick is added, updated or deleted